### PR TITLE
Add Back Learned ROM

### DIFF
--- a/src/multitask_personalization/rom/models.py
+++ b/src/multitask_personalization/rom/models.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pybullet as p
+import torch
 from numpy.typing import NDArray
 from scipy.spatial import KDTree
 
@@ -13,7 +14,11 @@ from multitask_personalization.envs.pybullet.pybullet_human_spec import (
     HumanSpec,
     create_human_from_spec,
 )
+from multitask_personalization.rom.implicit_mlp import MLPROMClassifierTorch
 from multitask_personalization.utils import (
+    DIMENSION_LIMITS,
+    DIMENSION_NAMES,
+    denormalize_samples,
     rotation_matrix_x,
     rotation_matrix_y,
     rotmat2euler,
@@ -49,6 +54,52 @@ class ROMModel(abc.ABC):
     @abc.abstractmethod
     def sample_reachable_position(self, rng: np.random.Generator) -> NDArray:
         """Sample a reachable position."""
+
+    def _run_human_fk(self, joint_positions: NDArray) -> NDArray:
+        """Run forward kinematics for the human given joint positions."""
+
+        # Transform from collected data angle space into pybullet angle space.
+        shoulder_aa, shoulder_fe, shoulder_rot, elbow_flexion = joint_positions
+        shoulder_aa = -shoulder_aa
+        shoulder_rot -= 90
+        shoulder_rot = -shoulder_rot
+        local_rot_mat = (
+            rotation_matrix_y(90)
+            @ rotation_matrix_x(shoulder_aa)
+            @ rotation_matrix_y(shoulder_fe)
+            @ rotation_matrix_x(shoulder_rot)
+        )
+        transformed_angles = rotmat2euler(local_rot_mat, seq="YZX")
+        shoulder_x = transformed_angles[0] - 90
+        shoulder_y = transformed_angles[1]
+        shoulder_z = 180 - transformed_angles[2]
+        elbow = elbow_flexion
+
+        current_right_arm_joint_angles = self._human.get_joint_angles(
+            self._human.right_arm_joints
+        )
+        target_right_arm_angles = np.copy(current_right_arm_joint_angles)
+        shoulder_x_index = self._human.j_right_shoulder_x
+        shoulder_y_index = self._human.j_right_shoulder_y
+        shoulder_z_index = self._human.j_right_shoulder_z
+        elbow_index = self._human.j_right_elbow
+
+        target_right_arm_angles[shoulder_x_index] = np.radians(shoulder_x)
+        target_right_arm_angles[shoulder_y_index] = np.radians(shoulder_y)
+        target_right_arm_angles[shoulder_z_index] = np.radians(shoulder_z)
+        target_right_arm_angles[elbow_index] = np.radians(elbow)
+        other_idxs = set(self._human.right_arm_joints) - {
+            shoulder_x_index,
+            shoulder_y_index,
+            shoulder_z_index,
+            elbow_index,
+        }
+        assert np.allclose([target_right_arm_angles[i] for i in other_idxs], 0.0)
+        self._human.set_joint_angles(
+            self._human.right_arm_joints, target_right_arm_angles, use_limits=False
+        )
+        right_wrist_pos, _ = self._human.get_pos_orient(self._human.right_wrist)
+        return right_wrist_pos
 
     def _visualize_reachable_points(
         self,
@@ -141,52 +192,6 @@ class GroundTruthROMModel(ROMModel):
     def sample_reachable_position(self, rng: np.random.Generator) -> NDArray:
         return rng.choice(self._reachable_points)
 
-    def _run_human_fk(self, joint_positions: NDArray) -> NDArray:
-        """Run forward kinematics for the human given joint positions."""
-
-        # Transform from collected data angle space into pybullet angle space.
-        shoulder_aa, shoulder_fe, shoulder_rot, elbow_flexion = joint_positions
-        shoulder_aa = -shoulder_aa
-        shoulder_rot -= 90
-        shoulder_rot = -shoulder_rot
-        local_rot_mat = (
-            rotation_matrix_y(90)
-            @ rotation_matrix_x(shoulder_aa)
-            @ rotation_matrix_y(shoulder_fe)
-            @ rotation_matrix_x(shoulder_rot)
-        )
-        transformed_angles = rotmat2euler(local_rot_mat, seq="YZX")
-        shoulder_x = transformed_angles[0] - 90
-        shoulder_y = transformed_angles[1]
-        shoulder_z = 180 - transformed_angles[2]
-        elbow = elbow_flexion
-
-        current_right_arm_joint_angles = self._human.get_joint_angles(
-            self._human.right_arm_joints
-        )
-        target_right_arm_angles = np.copy(current_right_arm_joint_angles)
-        shoulder_x_index = self._human.j_right_shoulder_x
-        shoulder_y_index = self._human.j_right_shoulder_y
-        shoulder_z_index = self._human.j_right_shoulder_z
-        elbow_index = self._human.j_right_elbow
-
-        target_right_arm_angles[shoulder_x_index] = np.radians(shoulder_x)
-        target_right_arm_angles[shoulder_y_index] = np.radians(shoulder_y)
-        target_right_arm_angles[shoulder_z_index] = np.radians(shoulder_z)
-        target_right_arm_angles[elbow_index] = np.radians(elbow)
-        other_idxs = set(self._human.right_arm_joints) - {
-            shoulder_x_index,
-            shoulder_y_index,
-            shoulder_z_index,
-            elbow_index,
-        }
-        assert np.allclose([target_right_arm_angles[i] for i in other_idxs], 0.0)
-        self._human.set_joint_angles(
-            self._human.right_arm_joints, target_right_arm_angles, use_limits=False
-        )
-        right_wrist_pos, _ = self._human.get_pos_orient(self._human.right_wrist)
-        return right_wrist_pos
-
 
 class SphericalROMModel(ROMModel):
     """ROM model with spherical reachability."""
@@ -220,3 +225,112 @@ class SphericalROMModel(ROMModel):
             np.array(sample_spherical(self._sphere_center, self._radius, self._rng))
             for _ in range(n)
         ]
+
+
+class LearnedROMModel(ROMModel):
+    """ROM model learned from data."""
+
+    def __init__(
+        self,
+        human_spec: HumanSpec,
+        ik_distance_threshold: float = 1e-1,
+        seed: int = 0,
+    ) -> None:
+        super().__init__(human_spec)
+        self._ik_distance_threshold = ik_distance_threshold
+        self._rom_model = MLPROMClassifierTorch(
+            device="cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self._rom_model.load()
+        self._parameter_size = 4
+        self._rom_model_context_parameters = np.array([0.0251, -0.2047, 0.3738, 0.1586])
+        """Parameters generated from functional score encoder as samples from.
+
+        the learned distribution
+        - [-0.1040, -0.2353, 0.2436, 0.0986]
+        - [-0.1230, -0.1877,  0.2162,  0.1826]
+        - [-0.0645, -0.2141,  0.2723,  0.0986]
+        """
+
+        # generate a dense grid of joint-space points
+        grids = []
+        for dim_name in DIMENSION_NAMES:
+            grids.append(
+                np.linspace(
+                    DIMENSION_LIMITS[dim_name][0],
+                    DIMENSION_LIMITS[dim_name][1],
+                    40,
+                )
+            )
+        grid = np.meshgrid(*grids)
+        joint_angle_samples = np.vstack([g.ravel() for g in grid]).T
+        # normalize samples using DIMENSION_LIMITS
+        joint_angle_samples = np.array(joint_angle_samples)
+        for i, dim_name in enumerate(DIMENSION_NAMES):
+            dim_min, dim_max = DIMENSION_LIMITS[dim_name]
+            joint_angle_samples[:, i] = (joint_angle_samples[:, i] - dim_min) / (
+                dim_max - dim_min
+            )
+        self._dense_joint_samples = joint_angle_samples
+        self.update_parameters(self._rom_model_context_parameters)
+        print("Learned ROM model created")
+
+        # Uncomment for debugging.
+        # self._visualize_reachable_points()
+
+    def get_parameter_size(self) -> int:
+        """Get the size of the parameter."""
+        return self._parameter_size
+
+    def get_rom_model_context_parameters(self) -> NDArray:
+        """Get the ROM model context parameters."""
+        return self._rom_model_context_parameters
+
+    def get_reachable_points(self) -> list[NDArray]:
+        """Get the reachable points."""
+        return self._reachable_points
+
+    def update_parameters(self, parameters: NDArray) -> None:
+        """Update the ROM model parameters."""
+        self._rom_model_context_parameters = parameters
+        # forward pass through the model to get the dense grid of reachable
+        # points in task space
+        context_parameters = np.tile(
+            self._rom_model_context_parameters, (len(self._dense_joint_samples), 1)
+        )
+        input_data = np.concatenate(
+            (context_parameters, self._dense_joint_samples), axis=1
+        )
+        preds = (
+            self._rom_model.classify(
+                torch.tensor(input_data, dtype=torch.float32).to(self._rom_model.device)
+            )
+            .detach()
+            .cpu()
+            .numpy()
+            .astype(np.bool_)
+        )
+        num_pos = np.sum(preds == 1)
+        num_neg = np.sum(preds == 0)
+        print(f"Number of positive samples: {num_pos}")
+        print(f"Number of negative samples: {num_neg}")
+
+        self._reachable_joints = denormalize_samples(
+            self._dense_joint_samples[preds == 1]
+        )
+        self._reachable_points = [
+            self._run_human_fk(point) for point in self._reachable_joints
+        ]
+        assert len(self._reachable_points) != 0, "No reachable points."
+        self._reachable_kd_tree = KDTree(self._reachable_points)
+        print(
+            f"Updated ROM model parameters, resulting in {len(self._reachable_points)}"
+            " reachable points."
+        )
+
+    def check_position_reachable(self, position: NDArray) -> bool:
+        distance, _ = self._reachable_kd_tree.query(position)
+        return distance < self._ik_distance_threshold
+
+    def sample_reachable_position(self, rng: np.random.Generator) -> NDArray:
+        return rng.choice(self._reachable_points)

--- a/tests/rom/test_learned_rom.py
+++ b/tests/rom/test_learned_rom.py
@@ -1,0 +1,34 @@
+"""Tests for rom/models.py."""
+
+import numpy as np
+
+from multitask_personalization.envs.pybullet.pybullet_task_spec import (
+    PyBulletTaskSpec,
+)
+from multitask_personalization.rom.models import LearnedROMModel
+
+
+def test_learned_rom_model():
+    """Tests for pybullet.py."""
+    seed = 123
+
+    rng = np.random.default_rng(seed)
+
+    task_spec = PyBulletTaskSpec()
+    learned_rom_model = LearnedROMModel(task_spec.human_spec, seed=seed)
+
+    # Test LearnedROMModel
+    assert (
+        len(learned_rom_model.get_rom_model_context_parameters())
+        == learned_rom_model.get_parameter_size()
+    )
+    # Test update_parameters is updating the parameters and reachable_points
+    parameters = learned_rom_model.get_rom_model_context_parameters()
+    # add small gaussian noise to parameters
+    n_prev_reachable_points = len(learned_rom_model.get_reachable_points())
+    noise = rng.normal(0, 2e-1, len(parameters))
+    learned_rom_model.update_parameters(parameters + noise)
+    assert np.allclose(
+        learned_rom_model.get_rom_model_context_parameters(), parameters + noise
+    )
+    assert len(learned_rom_model.get_reachable_points()) != n_prev_reachable_points

--- a/tests/rom/test_learned_rom.py
+++ b/tests/rom/test_learned_rom.py
@@ -9,7 +9,7 @@ from multitask_personalization.rom.models import LearnedROMModel
 
 
 def test_learned_rom_model():
-    """Tests for pybullet.py."""
+    """Tests for rom/models.py."""
     seed = 123
 
     rng = np.random.default_rng(seed)

--- a/tests/rom/test_spherical_rom.py
+++ b/tests/rom/test_spherical_rom.py
@@ -16,7 +16,7 @@ from multitask_personalization.utils import (
 
 
 def test_spherical_rom_model():
-    """Tests for pybullet.py."""
+    """Tests for rom/models.py."""
     seed = 123
 
     rng = np.random.default_rng(seed)


### PR DESCRIPTION
This adds back the learned rom model along with a simple unit test. There are two things that can potentially be cached, but are not cached:
- The densely sampled grid in the joint space. This can be cached, but generating this using `np.linspace` doesn't add too much overhead I believe.
- The computed `_reachable_joints`. This is dependent on the context parameters of the model and will be updated whenever the `_rom_model_context_parameters` change. We can cache these by using a fixed-precision printout of the parameter array as the file name, but we'll be getting a lot of cache files we the parameters gets updated a lot during any kind of "calibration" process.
Let me know if you prefer to have either or both of these cached!