### PR TITLE
Lifelong learning with periodic reset in cooking

### DIFF
--- a/experiments/analysis/plot_main_results.py
+++ b/experiments/analysis/plot_main_results.py
@@ -34,6 +34,20 @@ APPROACH_TO_COLOR = {
     "no_learning": "#fee08b",
 }
 
+# Colors for preference shift backgrounds
+SHIFT_COLORS = [
+    "#C6E2FF",  # Pale blue
+    "#FFB6C1",  # Light pink
+    "#98FB98",  # Pale green
+    "#DDA0DD",  # Plum
+    "#F0E68C",  # Khaki
+    "#E6E6FA",  # Lavender
+    "#FFA07A",  # Light salmon
+    "#B0E0E6",  # Powder blue
+    "#D8BFD8",  # Thistle
+    "#FFDAB9",  # Peach puff
+]
+
 
 def _create_config_fn(
     env_name: str, approach_name: str
@@ -43,6 +57,34 @@ def _create_config_fn(
         return cfg.env_name == env_name and cfg.approach_name == approach_name
 
     return _fn
+
+
+def _get_shift_times(results_dir: Path, env_name: str, approach_name: str) -> list[int]:
+    """Get the times when preference shifts occurred from the results files."""
+    config_fn = _create_config_fn(env_name, approach_name)
+    df = combine_results_csvs(results_dir, config_fn=config_fn)
+    if df.empty:
+        return []
+
+    # Get all times where a shift occurred
+    shift_df = df[
+        df["preference_shift"] == True  # pylint: disable=singleton-comparison
+    ]
+    print(f"shift_df: {shift_df}")
+    if shift_df.empty:
+        return []
+
+    # Get the evaluation times
+    eval_times = df["training_execution_time"].tolist()
+
+    # For each shift, find the previous evaluation time
+    shift_times = []
+    for shift_time in shift_df["training_execution_time"]:
+        # Find the index of the evaluation time that's just before the shift
+        prev_eval_idx = max(0, eval_times.index(shift_time) - 1)
+        shift_times.append(eval_times[prev_eval_idx])
+
+    return sorted(set(shift_times))  # Ensure times are in order
 
 
 def _main(results_dir: Path, outfile: Path) -> None:
@@ -62,6 +104,35 @@ def _main(results_dir: Path, outfile: Path) -> None:
         ax.set_title(env_display_name)
         ax.set_xlabel("Simulated Execution Time")
         ax.set_ylim((-1.05, 1.05))
+
+        # Colored background sections for preference shifts
+        if env_name == "cooking-nonstationary":
+            # Get shift times from the first approach's results
+            first_approach = list(APPROACH_TO_DISPLAY_NAME.keys())[0]
+            shift_times = _get_shift_times(results_dir, env_name, first_approach)
+
+            if shift_times:
+                # Get the maximum execution time from the data
+                df = combine_results_csvs(
+                    results_dir, config_fn=_create_config_fn(env_name, first_approach)
+                )
+                max_time = df["training_execution_time"].max()
+
+                # Create sections between shifts
+                section_starts = [0] + shift_times
+                section_ends = shift_times + [max_time]
+
+                print(f"section_starts: {section_starts}")
+                print(f"section_ends: {section_ends}")
+                # Add colored background sections
+                for j, (start, end) in enumerate(zip(section_starts, section_ends)):
+                    print(f"start: {start}, end: {end}")
+                    ax.axvspan(
+                        start, end, alpha=0.4, color=SHIFT_COLORS[j % len(SHIFT_COLORS)]
+                    )
+                # Add vertical lines for shift times
+                for shift_time in shift_times:
+                    ax.axvline(x=shift_time, color="gray", linestyle="--", alpha=0.5)
 
         for approach_name, approach_display_name in APPROACH_TO_DISPLAY_NAME.items():
             print(f"Combining results for {env_name}, {approach_name}")
@@ -101,6 +172,8 @@ def _main(results_dir: Path, outfile: Path) -> None:
 
     plt.savefig(outfile, dpi=1000, bbox_inches="tight", pad_inches=0.05)
     print(f"Wrote out to {outfile}")
+
+    plt.show()
 
 
 if __name__ == "__main__":

--- a/experiments/analysis/plot_main_results.py
+++ b/experiments/analysis/plot_main_results.py
@@ -11,9 +11,10 @@ from omegaconf import DictConfig
 
 ENV_TO_DISPLAY_NAME = {
     # "tiny": "Tiny",
+    "cooking-nonstationary": "Cooking (Non-Stationary)",
     "cooking-stationary": "Cooking",
-    "cleaning-stationary": "Cleaning",
-    "overnight-stationary": "Books",
+    # "cleaning-stationary": "Cleaning",
+    # "overnight-stationary": "Books",
 }
 
 APPROACH_TO_DISPLAY_NAME = {

--- a/experiments/conf/approach/epsilon_greedy.yaml
+++ b/experiments/conf/approach/epsilon_greedy.yaml
@@ -1,3 +1,9 @@
 defaults:
   - ours
+
 explore_method: epsilon-greedy
+
+lifelong_learning:
+  enabled: false
+  method: periodic_reset
+  reset_interval: 100

--- a/experiments/conf/approach/exploit_only.yaml
+++ b/experiments/conf/approach/exploit_only.yaml
@@ -1,3 +1,9 @@
 defaults:
   - ours
+
 explore_method: exploit-only
+
+lifelong_learning:
+  enabled: false
+  method: periodic_reset
+  reset_interval: 100

--- a/experiments/conf/approach/no_learning.yaml
+++ b/experiments/conf/approach/no_learning.yaml
@@ -1,4 +1,10 @@
 defaults:
   - ours
+
 explore_method: nothing-personal  # doesn't matter, just pick a fast one
 disable_learning: true
+
+lifelong_learning:
+  enabled: false
+  method: periodic_reset
+  reset_interval: 100

--- a/experiments/conf/approach/nothing_personal.yaml
+++ b/experiments/conf/approach/nothing_personal.yaml
@@ -1,3 +1,9 @@
 defaults:
   - ours
+
 explore_method: nothing-personal
+
+lifelong_learning:
+  enabled: false
+  method: periodic_reset
+  reset_interval: 100

--- a/experiments/conf/approach/ours.yaml
+++ b/experiments/conf/approach/ours.yaml
@@ -4,3 +4,8 @@ explore_method: max-entropy
 csp_solver: ${csp_solver}
 llm: ${llm}
 disable_learning: false
+
+lifelong_learning:
+  enabled: true
+  method: periodic_reset
+  reset_interval: 2500  # Number of feedbacks before resetting memory

--- a/experiments/conf/env/cooking-nonstationary.yaml
+++ b/experiments/conf/env/cooking-nonstationary.yaml
@@ -7,8 +7,8 @@ env:
     meal_preference_model:
       preference_shift_spec:
         _target_: "multitask_personalization.envs.cooking.cooking_structs.PreferenceShiftSpec"
-        min_shift_interval: 100
-        shift_prob: 0.5
+        min_shift_interval: 2500
+        shift_prob: 1.0
         shift_factor_range: [0.9, 1.1]
   # note: seed is excluded because it varies for train/eval envs
 # train_env: {}

--- a/experiments/conf/env/cooking-nonstationary.yaml
+++ b/experiments/conf/env/cooking-nonstationary.yaml
@@ -1,0 +1,24 @@
+defaults:
+  - cooking
+  - _self_
+
+env:
+  hidden_spec:
+    meal_preference_model:
+      preference_shift_spec:
+        _target_: "multitask_personalization.envs.cooking.cooking_structs.PreferenceShiftSpec"
+        min_shift_interval: 100
+        shift_prob: 0.5
+        shift_factor_range: [0.9, 1.1]
+  # note: seed is excluded because it varies for train/eval envs
+# train_env: {}
+# eval_env: {}
+max_environment_steps: 10000
+eval_frequency: 100
+max_eval_episode_length: 100
+num_eval_trials: 10
+dt: 0.01
+csp_solver:
+  max_iters: 100_000
+  num_improvements: 500
+  max_improvement_attempts: 10_000

--- a/experiments/conf/env/cooking.yaml
+++ b/experiments/conf/env/cooking.yaml
@@ -10,14 +10,22 @@ env:
         - _target_: "multitask_personalization.envs.cooking.cooking_meals.MealSpec"
           name: "seasoning"
           ingredients:
+            # - _target_: "multitask_personalization.envs.cooking.cooking_meals.IngredientSpec"
+            #   name: "salt"
+            #   temperature: [2.8, 3.2]
+            #   quantity: [0.95, 1.0]
+            # - _target_: "multitask_personalization.envs.cooking.cooking_meals.IngredientSpec"
+            #   name: "pepper"
+            #   temperature: [2.8, 3.2]
+            #   quantity: [0.95, 1.0]
             - _target_: "multitask_personalization.envs.cooking.cooking_meals.IngredientSpec"
               name: "salt"
-              temperature: [2.8, 3.2]
-              quantity: [0.95, 1.0]
+              temperature: [2.6, 3.2]
+              quantity: [0.85, 1.05]
             - _target_: "multitask_personalization.envs.cooking.cooking_meals.IngredientSpec"
               name: "pepper"
-              temperature: [2.8, 3.2]
-              quantity: [0.95, 1.0]
+              temperature: [2.6, 3.2]
+              quantity: [0.85, 1.05]
       preference_shift_spec:
         _target_: "multitask_personalization.envs.cooking.cooking_structs.PreferenceShiftSpec"
         min_shift_interval: 8

--- a/experiments/run_single_experiment.py
+++ b/experiments/run_single_experiment.py
@@ -15,6 +15,9 @@ from omegaconf import DictConfig, OmegaConf
 
 from multitask_personalization.methods.approach import BaseApproach
 
+# Environments that support preference shifts
+PREFERENCE_SHIFT_ENVS = ["cooking-nonstationary"]
+
 
 @hydra.main(version_base=None, config_name="config", config_path="conf/")
 def _main(cfg: DictConfig) -> None:
@@ -92,9 +95,10 @@ def _main(cfg: DictConfig) -> None:
     train_metrics: list[dict[str, float]] = []
     eval_metrics: list[dict[str, float]] = []
 
+    shift_occurred_since_last_eval = False
+
     # Catch any exceptions so we can debug from the last saved state.
     try:
-
         # Reset the training environment, one time only.
         obs, info = train_env.reset()
         # Reset the training approach, one time only.
@@ -103,10 +107,12 @@ def _main(cfg: DictConfig) -> None:
         for t in range(cfg.env.max_environment_steps + 1):
             if t % cfg.train_logging_interval == 0:
                 logging.info(f"Starting training step {t}")
-                
+
             # Check if it's time to eval.
             if cfg.env.eval_frequency > 0 and t % cfg.env.eval_frequency == 0:
-                logging.info(f"======================= Evaluation at step {t} =======================")
+                logging.info(
+                    f"===================== Evaluation at step {t} ====================="
+                )
                 # Save the models from the training approach and load them into the
                 # eval approach.
                 step_model_dir = model_dir / str(t)
@@ -114,10 +120,24 @@ def _main(cfg: DictConfig) -> None:
                 train_approach.save(step_model_dir)
                 eval_approach.load(step_model_dir)
 
-                # For nonstationary environments, we need to sync the hidden specs of train env to eval env
-                eval_env._hidden_spec.meal_preference_model.sync_variables(train_env._hidden_spec.meal_preference_model) # pylint: disable=protected-access
+                # For environments that support preference shifts, sync the hidden specs
+                if cfg.env_name in PREFERENCE_SHIFT_ENVS:
+                    if cfg.env_name == "cooking-nonstationary":
+                        eval_env._hidden_spec.meal_preference_model.sync_variables(  # pylint: disable=protected-access
+                            train_env._hidden_spec.meal_preference_model  # pylint: disable=protected-access
+                        )
                 # Run evaluation.
-                step_eval_metrics = _evaluate_approach(eval_approach, eval_env, cfg, t)
+                step_eval_metrics = _evaluate_approach(
+                    eval_approach,
+                    eval_env,
+                    cfg,
+                    t,
+                    (
+                        shift_occurred_since_last_eval
+                        if cfg.env_name in PREFERENCE_SHIFT_ENVS
+                        else False
+                    ),
+                )
                 if cfg.wandb.enable:
                     wandb_metrics = {
                         f"eval/{k}": v for k, v in step_eval_metrics.items()
@@ -126,7 +146,11 @@ def _main(cfg: DictConfig) -> None:
                     wandb.log(wandb_metrics, step=t)
                 eval_metrics.append(step_eval_metrics)
                 logging.info("Resuming training")
-                logging.info("=========================================================")
+                logging.info(
+                    "========================================================="
+                )
+                # Reset shift tracking
+                shift_occurred_since_last_eval = False
             # Eval on the last time step but don't train anymore.
             if t >= cfg.env.max_environment_steps:
                 break
@@ -137,13 +161,20 @@ def _main(cfg: DictConfig) -> None:
             # During training, there is no such thing as termination.
             terminated = False
             train_approach.update(obs, float(rew), terminated, info)
-            user_satisfaction = info.get("user_satisfaction", np.nan)
-            env_video_should_pause = info.get("env_video_should_pause", False)
+
+            # Track if any shift occurred during training
+            preference_shift = False
+            if cfg.env_name in PREFERENCE_SHIFT_ENVS:
+                preference_shift = info.get("preference_shift", False)
+                if preference_shift:
+                    shift_occurred_since_last_eval = True
+
             step_train_metrics = {
                 "step": t,
                 "execution_time": t * cfg.env.dt,
-                "user_satisfaction": user_satisfaction,
-                "env_video_should_pause": env_video_should_pause,
+                "user_satisfaction": info.get("user_satisfaction", np.nan),
+                "env_video_should_pause": info.get("env_video_should_pause", False),
+                "preference_shift": preference_shift,
                 **train_approach.get_step_metrics(),
             }
             if cfg.wandb.enable:
@@ -151,6 +182,7 @@ def _main(cfg: DictConfig) -> None:
                 del wandb_metrics["train/step"]
                 wandb.log(wandb_metrics, step=t)
             train_metrics.append(step_train_metrics)
+
         train_env.close()
         eval_env.close()
 
@@ -189,7 +221,11 @@ def _main(cfg: DictConfig) -> None:
 
 
 def _evaluate_approach(
-    eval_approach: BaseApproach, eval_env: gym.Env, cfg: DictConfig, training_step: int
+    eval_approach: BaseApproach,
+    eval_env: gym.Env,
+    cfg: DictConfig,
+    training_step: int,
+    shift_occurred_since_last_eval: bool,
 ) -> dict[str, float]:
     """Evaluate the given approach and return metrics."""
     # Evaluate for a given number of trials.
@@ -215,6 +251,7 @@ def _evaluate_approach(
     step_eval_metrics: dict[str, float] = {
         "training_step": training_step,
         "training_execution_time": training_step * cfg.env.dt,
+        "preference_shift": shift_occurred_since_last_eval,
     }
     for idx, cus in enumerate(cumulative_user_satisfactions):
         step_eval_metrics[f"eval_episode_{idx}_user_satisfaction"] = cus

--- a/experiments/run_single_experiment.py
+++ b/experiments/run_single_experiment.py
@@ -51,7 +51,7 @@ def _main(cfg: DictConfig) -> None:
 
     # Create training environment, which should only be reset once.
     train_env_cfg = OmegaConf.merge(cfg.env.env, cfg.env.train_env)
-    train_env = hydra.utils.instantiate(train_env_cfg, seed=cfg.seed)
+    train_env = hydra.utils.instantiate(train_env_cfg, seed=cfg.seed, eval_mode=False)
     assert isinstance(train_env, gym.Env)
     if cfg.record_train_videos:
         train_env = gym.wrappers.RecordVideo(
@@ -62,7 +62,7 @@ def _main(cfg: DictConfig) -> None:
     # Create eval environment, which will be reset all the time.
     eval_seed = cfg.seed + cfg.eval_seed_offset
     eval_env_cfg = OmegaConf.merge(cfg.env.env, cfg.env.eval_env)
-    eval_env = hydra.utils.instantiate(eval_env_cfg, seed=eval_seed)
+    eval_env = hydra.utils.instantiate(eval_env_cfg, seed=eval_seed, eval_mode=True)
     assert isinstance(eval_env, gym.Env)
     if cfg.record_eval_videos:
         eval_env = gym.wrappers.RecordVideo(eval_env, str(Path(cfg.video_dir) / "eval"))
@@ -103,15 +103,19 @@ def _main(cfg: DictConfig) -> None:
         for t in range(cfg.env.max_environment_steps + 1):
             if t % cfg.train_logging_interval == 0:
                 logging.info(f"Starting training step {t}")
+                
             # Check if it's time to eval.
             if cfg.env.eval_frequency > 0 and t % cfg.env.eval_frequency == 0:
-
+                logging.info(f"======================= Evaluation at step {t} =======================")
                 # Save the models from the training approach and load them into the
                 # eval approach.
                 step_model_dir = model_dir / str(t)
                 step_model_dir.mkdir(exist_ok=True)
                 train_approach.save(step_model_dir)
                 eval_approach.load(step_model_dir)
+
+                # For nonstationary environments, we need to sync the hidden specs of train env to eval env
+                eval_env._hidden_spec.meal_preference_model.sync_variables(train_env._hidden_spec.meal_preference_model) # pylint: disable=protected-access
                 # Run evaluation.
                 step_eval_metrics = _evaluate_approach(eval_approach, eval_env, cfg, t)
                 if cfg.wandb.enable:
@@ -122,6 +126,7 @@ def _main(cfg: DictConfig) -> None:
                     wandb.log(wandb_metrics, step=t)
                 eval_metrics.append(step_eval_metrics)
                 logging.info("Resuming training")
+                logging.info("=========================================================")
             # Eval on the last time step but don't train anymore.
             if t >= cfg.env.max_environment_steps:
                 break

--- a/src/multitask_personalization/envs/cooking/cooking_csp.py
+++ b/src/multitask_personalization/envs/cooking/cooking_csp.py
@@ -383,6 +383,8 @@ class CookingCSPGenerator(CSPGenerator[CookingState, CookingAction]):
     def _update_meal_model(
         self, obs: CookingState, act: CookingAction, next_obs: CookingState
     ) -> None:
+        # lifelong learning, adapt to preference shift
+        self._meal_model.adapt_to_preference_shift()
         if not isinstance(act, ServeMealCookingAction):
             return
         meal = obs.get_meal(act.meal_name)

--- a/src/multitask_personalization/envs/cooking/cooking_env.py
+++ b/src/multitask_personalization/envs/cooking/cooking_env.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import Any, get_args
-import logging
 
 import gymnasium as gym
 import numpy as np
@@ -58,6 +57,7 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
         self._current_user_critiques: list[IngredientCritique] = []
 
         self._eval_mode = eval_mode
+        self._current_step = 0
 
     def _get_state_from_scene_spec(self, scene_spec: CookingSceneSpec) -> CookingState:
         # NOTE: the initial quantities of ingredients are randomized.
@@ -93,6 +93,7 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
         self._current_state = self._get_state_from_scene_spec(self.scene_spec)
         self._current_user_satisfaction = 0.0
         self._current_user_critiques = []
+        self._current_step = 0
         return self._get_state(), self._get_info()
 
     def step(
@@ -104,6 +105,7 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
         self._current_user_satisfaction = 0.0
         self._current_user_critiques = []
         done = False
+        preference_shift = False
 
         new_pot_states: list[CookingPotState] = []
         new_ingredients = self._current_state.ingredients.copy()
@@ -134,11 +136,6 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
             new_pot_states = self._current_state.pots
             new_ingredients = self._current_state.ingredients.copy()
             done = True  # used for eval
-
-            # Shift user preferences.
-            if not self._eval_mode:
-                self._hidden_spec.meal_preference_model.shift_preferences(self._rng)
-
         else:
             # Update pot temperatures and initialize new_pot_states.
             for pot_id, pot_state in enumerate(self._current_state.pots):
@@ -229,7 +226,17 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
             new_pot_states, new_ingredients, list(self._current_user_critiques)
         )
 
-        return self._get_state(), 0.0, done, False, self._get_info()
+        # Shift user preferences. This does not wait until the completion of a meal
+        if not self._eval_mode and self._hidden_spec is not None:
+            preference_shift = (
+                self._hidden_spec.meal_preference_model.shift_preferences(
+                    self._rng, self._current_step
+                )  # pylint: disable=line-too-long
+            )
+        # Increment step counter
+        self._current_step += 1
+
+        return self._get_state(), 0.0, done, False, self._get_info(preference_shift)
 
     def render(self) -> RenderFrame | list[RenderFrame] | None:
         pad = self.scene_spec.render_padding
@@ -283,9 +290,10 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
     def _get_state(self) -> CookingState:
         return self._current_state
 
-    def _get_info(self) -> dict[str, Any]:
+    def _get_info(self, preference_shift: bool = False) -> dict[str, Any]:
         return {
             "user_satisfaction": self._current_user_satisfaction,
+            "preference_shift": preference_shift,
         }
 
     def _pot_move_is_valid(

--- a/src/multitask_personalization/envs/cooking/cooking_env.py
+++ b/src/multitask_personalization/envs/cooking/cooking_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, get_args
+import logging
 
 import gymnasium as gym
 import numpy as np
@@ -38,6 +39,7 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
         scene_spec: CookingSceneSpec,
         hidden_spec: CookingHiddenSpec | None = None,
         seed: int = 0,
+        eval_mode: bool = False,
     ) -> None:
 
         self._rng = np.random.default_rng(seed)
@@ -54,6 +56,8 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
 
         self._current_user_satisfaction = 0.0
         self._current_user_critiques: list[IngredientCritique] = []
+
+        self._eval_mode = eval_mode
 
     def _get_state_from_scene_spec(self, scene_spec: CookingSceneSpec) -> CookingState:
         # NOTE: the initial quantities of ingredients are randomized.
@@ -132,7 +136,8 @@ class CookingEnv(gym.Env[CookingState, CookingAction]):
             done = True  # used for eval
 
             # Shift user preferences.
-            self._hidden_spec.meal_preference_model.shift_preferences(self._rng)
+            if not self._eval_mode:
+                self._hidden_spec.meal_preference_model.shift_preferences(self._rng)
 
         else:
             # Update pot temperatures and initialize new_pot_states.

--- a/src/multitask_personalization/envs/cooking/cooking_hidden_spec.py
+++ b/src/multitask_personalization/envs/cooking/cooking_hidden_spec.py
@@ -145,7 +145,6 @@ class MealSpecMealPreferenceModel(MealPreferenceModel):
         Returns:
             bool: True if a shift occurred, False otherwise
         """
-        # print(f"current_step: {current_step}")
         if (
             current_step > 0
             and current_step % self._min_shift_interval == 0

--- a/src/multitask_personalization/envs/cooking/cooking_hidden_spec.py
+++ b/src/multitask_personalization/envs/cooking/cooking_hidden_spec.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import abc
+import copy
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
-
-import copy
-import logging
 
 import numpy as np
 
@@ -63,20 +62,34 @@ class MealPreferenceModel(abc.ABC):
         """Load the meal model."""
 
     @abc.abstractmethod
-    def shift_preferences(self, rng: np.random.Generator) -> None:
-        """Shift the user's preferences."""
+    def shift_preferences(self, rng: np.random.Generator, current_step: int) -> bool:
+        """Shift the user's preferences.
+
+        Returns:
+            bool: True if a shift occurred, False otherwise
+        """
 
     @abc.abstractmethod
     def sync_variables(self, other) -> None:
-        """Sync the variables of this object with another object"""
+        """Sync the variables of this object with another object."""
+
+    @abc.abstractmethod
+    def adapt_to_preference_shift(self) -> None:
+        """Adapt the model to a preference shift by potentially resetting
+        memory."""
+
 
 class MealSpecMealPreferenceModel(MealPreferenceModel):
     """An explicit list of a user's meal preferences."""
 
     def __init__(
-        self, meal_specs: list[MealSpec], preference_shift_spec: PreferenceShiftSpec
+        self,
+        meal_specs: list[MealSpec],
+        preference_shift_spec: PreferenceShiftSpec,
+        lifelong_learning: dict | None = None,
     ) -> None:
         self._universal_meal_specs = {m.name: m for m in meal_specs}
+        print(f"self._universal_meal_specs: {self._universal_meal_specs}")
         assert len(self._universal_meal_specs) == len(
             meal_specs
         ), "Meal names must be unique"
@@ -99,11 +112,8 @@ class MealSpecMealPreferenceModel(MealPreferenceModel):
         # Lifelong learning setup.
         # If a shift occurs, all ingredients will shift at the same time.
         # The amount is sampled within a range.
-        # number of feedbacks given as a proxy for number of meals user had
-        # since the last shift
-        self._n_feedbacks_given = 0
 
-        # min number of meals before preference shift
+        # min number of steps before preference shift
         self._min_shift_interval = preference_shift_spec.min_shift_interval
         # probability of a preference shift
         self._shift_prob = preference_shift_spec.shift_prob
@@ -111,18 +121,46 @@ class MealSpecMealPreferenceModel(MealPreferenceModel):
         # Given old range [x-r, x+r], new range is [max(0, x*f-r), x*f+r]
         self._shift_factor_range = preference_shift_spec.shift_factor_range
 
+        # Lifelong learning configuration
+        self._lifelong_learning = lifelong_learning or {
+            "enabled": False,
+            "method": "periodic_reset",
+            "reset_interval": 100,
+        }
+        # Counter for tracking number of update calls
+        self._update_counter = 0
+
     def sync_variables(self, other):
-        """Sync the variables of this object with another object"""
+        """Sync the variables of this object with another object."""
         assert isinstance(other, self.__class__)
-        self._universal_meal_specs = copy.deepcopy(other._universal_meal_specs)
-        self._n_feedbacks_given = copy.deepcopy(other._n_feedbacks_given)
-        # the models don't matter because the model update happens in the approach copies of hidden spec
-        
-    def shift_preferences(self, rng: np.random.Generator) -> None:
+        self._universal_meal_specs = copy.deepcopy(
+            other._universal_meal_specs  # pylint: disable=protected-access
+        )
+        # the models don't matter because the model update happens
+        # in the approach copies of hidden spec
+
+    def shift_preferences(self, rng: np.random.Generator, current_step: int) -> bool:
+        """Shift the user's preferences.
+
+        Returns:
+            bool: True if a shift occurred, False otherwise
+        """
+        # print(f"current_step: {current_step}")
         if (
-            self._n_feedbacks_given >= self._min_shift_interval
+            current_step > 0
+            and current_step % self._min_shift_interval == 0
             and rng.uniform() < self._shift_prob
         ):
+            # print the ingredient preferences before shift
+            logging.info("Ingredient preferences before shift:")
+            for meal_name, meal_spec in self._universal_meal_specs.items():
+                logging.info(f"Meal: {meal_name}")
+                for ing_spec in meal_spec.ingredients:
+                    logging.info(
+                        f"Ingredient: {ing_spec.name}, "
+                        + f"Temperature: {ing_spec.temperature}, "
+                        + f"Quantity: {ing_spec.quantity}"
+                    )
             ing_shift_factors = {}
             for meal_name, meal_spec in self._universal_meal_specs.items():
                 shifted_ing_specs = []
@@ -162,11 +200,56 @@ class MealSpecMealPreferenceModel(MealPreferenceModel):
                 self._universal_meal_specs[meal_name] = MealSpec(
                     meal_name, shifted_ing_specs
                 )
-            
+
+            # print the ingredient preferences after shift
+            logging.info("Ingredient preferences after shift:")
+            for meal_name, meal_spec in self._universal_meal_specs.items():
+                logging.info(f"Meal: {meal_name}")
+                for ing_spec in meal_spec.ingredients:
+                    logging.info(
+                        f"Ingredient: {ing_spec.name}, "
+                        + f"Temperature: {ing_spec.temperature}, "
+                        + f"Quantity: {ing_spec.quantity}"
+                    )
+
             # log ing_shift_factors
-            logging.info(f"Shifted preferences for {self._n_feedbacks_given} meals with factors {ing_shift_factors}")
-            # Reset counter after shift.
-            self._n_feedbacks_given = 0
+            logging.info(
+                f"Shifted preferences at step {current_step} with "
+                + f"factors {ing_shift_factors}"
+            )
+
+            return True
+        return False
+
+    def adapt_to_preference_shift(self) -> None:
+        """Adapt the model to a preference shift by potentially resetting
+        memory."""
+        self._update_counter += 1
+        if self._lifelong_learning["enabled"]:
+            # logging.info(f"Total update calls: {self._update_counter}")
+            if (
+                self._lifelong_learning["method"] == "periodic_reset"
+                and self._update_counter > 1
+                and (self._update_counter - 1)
+                % self._lifelong_learning["reset_interval"]
+                == 0
+            ):
+                logging.info(f"Resetting memory after {self._update_counter} updates")
+                # reset for all meals and all ingredients
+                self._temperature_models = {}
+                self._quantity_models = {}
+                for meal_name, meal_spec in self._universal_meal_specs.items():
+                    self._temperature_models[meal_name] = {}
+                    self._quantity_models[meal_name] = {}
+                    for ing_spec in meal_spec.ingredients:
+                        temp_lo, temp_hi = ing_spec.temperature
+                        self._temperature_models[meal_name][ing_spec.name] = (
+                            Bounded1DClassifier(temp_lo, temp_hi)
+                        )
+                        quant_lo, quant_hi = ing_spec.quantity
+                        self._quantity_models[meal_name][ing_spec.name] = (
+                            Bounded1DClassifier(quant_lo, quant_hi)
+                        )
 
     def sample(self, rng: np.random.Generator) -> Meal:
         meal_spec_idx = rng.choice(len(self._universal_meal_specs))
@@ -226,41 +309,10 @@ class MealSpecMealPreferenceModel(MealPreferenceModel):
                 missing=missing,
             )
             critiques.append(critique)
-        self._n_feedbacks_given += 1
 
         return critiques
 
     def update(self, meal: Meal, critiques: list[IngredientCritique]) -> None:
-        
-        # FIXME: testing reset memory after set period
-        local_total_feedback = 0
-        # iterate over all temp models, find total number of feedbacks across all meals
-        for meal_temp_model in self._temperature_models.values():
-            for ing_temp_model in meal_temp_model.values():
-                local_total_feedback += len(ing_temp_model.incremental_X)
-                break
-        # add current feedback
-        logging.info(f"Total feedbacks across all meals {local_total_feedback}")
-        # FIXME: testing reset memory after set period
-        if local_total_feedback % 100 == 0:
-            logging.info(f"Resetting memory after {local_total_feedback} meals")
-            # reset for all meals and all ingredients
-            self._temperature_models: dict[str, dict[str, Bounded1DClassifier]] = {}
-            self._quantity_models: dict[str, dict[str, Bounded1DClassifier]] = {}
-            for meal_name, meal_spec in self._universal_meal_specs.items():
-                self._temperature_models[meal_name] = {}
-                self._quantity_models[meal_name] = {}
-                for ing_spec in meal_spec.ingredients:
-                    temp_lo, temp_hi = ing_spec.temperature
-                    self._temperature_models[meal_name][ing_spec.name] = (
-                        Bounded1DClassifier(temp_lo, temp_hi)
-                    )
-                    quant_lo, quant_hi = ing_spec.quantity
-                    self._quantity_models[meal_name][ing_spec.name] = Bounded1DClassifier(
-                        quant_lo,
-                        quant_hi,
-                    )
-
         for critique in critiques:
             assert not critique.missing
             meal_temp, meal_quant = meal.ingredients[critique.ingredient]

--- a/src/multitask_personalization/envs/cooking/cooking_hidden_spec.py
+++ b/src/multitask_personalization/envs/cooking/cooking_hidden_spec.py
@@ -7,6 +7,9 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+import copy
+import logging
+
 import numpy as np
 
 from multitask_personalization.envs.cooking.cooking_meals import (
@@ -63,6 +66,9 @@ class MealPreferenceModel(abc.ABC):
     def shift_preferences(self, rng: np.random.Generator) -> None:
         """Shift the user's preferences."""
 
+    @abc.abstractmethod
+    def sync_variables(self, other) -> None:
+        """Sync the variables of this object with another object"""
 
 class MealSpecMealPreferenceModel(MealPreferenceModel):
     """An explicit list of a user's meal preferences."""
@@ -105,6 +111,13 @@ class MealSpecMealPreferenceModel(MealPreferenceModel):
         # Given old range [x-r, x+r], new range is [max(0, x*f-r), x*f+r]
         self._shift_factor_range = preference_shift_spec.shift_factor_range
 
+    def sync_variables(self, other):
+        """Sync the variables of this object with another object"""
+        assert isinstance(other, self.__class__)
+        self._universal_meal_specs = copy.deepcopy(other._universal_meal_specs)
+        self._n_feedbacks_given = copy.deepcopy(other._n_feedbacks_given)
+        # the models don't matter because the model update happens in the approach copies of hidden spec
+        
     def shift_preferences(self, rng: np.random.Generator) -> None:
         if (
             self._n_feedbacks_given >= self._min_shift_interval
@@ -149,7 +162,9 @@ class MealSpecMealPreferenceModel(MealPreferenceModel):
                 self._universal_meal_specs[meal_name] = MealSpec(
                     meal_name, shifted_ing_specs
                 )
-
+            
+            # log ing_shift_factors
+            logging.info(f"Shifted preferences for {self._n_feedbacks_given} meals with factors {ing_shift_factors}")
             # Reset counter after shift.
             self._n_feedbacks_given = 0
 
@@ -212,9 +227,40 @@ class MealSpecMealPreferenceModel(MealPreferenceModel):
             )
             critiques.append(critique)
         self._n_feedbacks_given += 1
+
         return critiques
 
     def update(self, meal: Meal, critiques: list[IngredientCritique]) -> None:
+        
+        # FIXME: testing reset memory after set period
+        local_total_feedback = 0
+        # iterate over all temp models, find total number of feedbacks across all meals
+        for meal_temp_model in self._temperature_models.values():
+            for ing_temp_model in meal_temp_model.values():
+                local_total_feedback += len(ing_temp_model.incremental_X)
+                break
+        # add current feedback
+        logging.info(f"Total feedbacks across all meals {local_total_feedback}")
+        # FIXME: testing reset memory after set period
+        if local_total_feedback % 100 == 0:
+            logging.info(f"Resetting memory after {local_total_feedback} meals")
+            # reset for all meals and all ingredients
+            self._temperature_models: dict[str, dict[str, Bounded1DClassifier]] = {}
+            self._quantity_models: dict[str, dict[str, Bounded1DClassifier]] = {}
+            for meal_name, meal_spec in self._universal_meal_specs.items():
+                self._temperature_models[meal_name] = {}
+                self._quantity_models[meal_name] = {}
+                for ing_spec in meal_spec.ingredients:
+                    temp_lo, temp_hi = ing_spec.temperature
+                    self._temperature_models[meal_name][ing_spec.name] = (
+                        Bounded1DClassifier(temp_lo, temp_hi)
+                    )
+                    quant_lo, quant_hi = ing_spec.quantity
+                    self._quantity_models[meal_name][ing_spec.name] = Bounded1DClassifier(
+                        quant_lo,
+                        quant_hi,
+                    )
+
         for critique in critiques:
             assert not critique.missing
             meal_temp, meal_quant = meal.ingredients[critique.ingredient]

--- a/src/multitask_personalization/envs/cooking/cooking_meals.py
+++ b/src/multitask_personalization/envs/cooking/cooking_meals.py
@@ -70,11 +70,18 @@ class Meal:
 
 
 DEFAULT_MEAL_SPECS = [
+    # MealSpec(
+    #     "seasoning",
+    #     [
+    #         IngredientSpec("salt", temperature=(2.5, 3.5), quantity=(0.9, 1.1)),
+    #         IngredientSpec("pepper", temperature=(2.5, 3.5), quantity=(0.9, 1.1)),
+    #     ],
+    # )
     MealSpec(
         "seasoning",
         [
-            IngredientSpec("salt", temperature=(2.5, 3.5), quantity=(0.9, 1.1)),
-            IngredientSpec("pepper", temperature=(2.5, 3.5), quantity=(0.9, 1.1)),
+            IngredientSpec("salt", temperature=(1.0, 5.0), quantity=(0.2, 2.0)),
+            IngredientSpec("pepper", temperature=(1.0, 5.0), quantity=(0.2, 2.0)),
         ],
     )
 ]

--- a/src/multitask_personalization/envs/cooking/cooking_meals.py
+++ b/src/multitask_personalization/envs/cooking/cooking_meals.py
@@ -80,8 +80,8 @@ DEFAULT_MEAL_SPECS = [
     MealSpec(
         "seasoning",
         [
-            IngredientSpec("salt", temperature=(1.0, 5.0), quantity=(0.2, 2.0)),
-            IngredientSpec("pepper", temperature=(1.0, 5.0), quantity=(0.2, 2.0)),
+            IngredientSpec("salt", temperature=(2.0, 4.0), quantity=(0.7, 1.3)),
+            IngredientSpec("pepper", temperature=(2.0, 4.0), quantity=(0.7, 1.3)),
         ],
     )
 ]

--- a/src/multitask_personalization/envs/cooking/cooking_structs.py
+++ b/src/multitask_personalization/envs/cooking/cooking_structs.py
@@ -163,7 +163,7 @@ class PreferenceShiftSpec:
 
 
 DEFAULT_PREFERENCE_SHIFT_SPEC = PreferenceShiftSpec(
-    min_shift_interval=5,
-    shift_prob=0.2,
+    min_shift_interval=2500,
+    shift_prob=0.0,
     shift_factor_range=(0.0, 2.0),
 )

--- a/src/multitask_personalization/envs/feeding/feeding_env.py
+++ b/src/multitask_personalization/envs/feeding/feeding_env.py
@@ -63,6 +63,7 @@ class FeedingEnv(gym.Env[FeedingState, FeedingAction]):
         hidden_spec: FeedingHiddenSceneSpec | None = None,
         use_gui: bool = False,
         seed: int = 0,
+        eval_mode: bool = False,
     ) -> None:
         self._rng = np.random.default_rng(seed)
         self._seed = seed
@@ -222,6 +223,8 @@ class FeedingEnv(gym.Env[FeedingState, FeedingAction]):
 
         # See get_joint_positions_from_known_ee_pose().
         self._known_ee_poses: dict[tuple[float, ...], JointPositions] = {}
+
+        self._eval_mode = eval_mode
 
         # Uncomment to debug.
         # if use_gui:

--- a/src/multitask_personalization/envs/pybullet/pybullet_env.py
+++ b/src/multitask_personalization/envs/pybullet/pybullet_env.py
@@ -74,6 +74,7 @@ class PyBulletEnv(gym.Env[PyBulletState, PyBulletAction]):
         use_gui: bool = False,
         use_eval_distribution: bool = False,
         seed: int = 0,
+        eval_mode: bool = False,
     ) -> None:
 
         self._rng = np.random.default_rng(seed)
@@ -326,6 +327,8 @@ class PyBulletEnv(gym.Env[PyBulletState, PyBulletAction]):
 
         # For rendering.
         self._timestep = 0
+
+        self._eval_mode = eval_mode
 
         # Uncomment for debug / development.
         # if use_gui:

--- a/src/multitask_personalization/envs/tiny/tiny_env.py
+++ b/src/multitask_personalization/envs/tiny/tiny_env.py
@@ -50,6 +50,7 @@ class TinyEnv(gym.Env[TinyState, TinyAction]):
         scene_spec: TinySceneSpec,
         hidden_spec: TinyHiddenSpec | None = None,
         seed: int = 0,
+        eval_mode: bool = False,
     ) -> None:
 
         self._rng = np.random.default_rng(seed)
@@ -66,6 +67,8 @@ class TinyEnv(gym.Env[TinyState, TinyAction]):
         # Reset in reset().
         self._robot_position = -1.0
         self._human_position = 1.0
+
+        self._eval_mode = eval_mode
 
     def reset(
         self,

--- a/src/multitask_personalization/methods/csp_approach.py
+++ b/src/multitask_personalization/methods/csp_approach.py
@@ -52,6 +52,7 @@ class CSPApproach(BaseApproach[_ObsType, _ActType]):
         disable_learning: bool = False,
         csp_save_dir: str | None = None,
         seed: int = 0,
+        lifelong_learning: dict | None = None,
     ):
         super().__init__(scene_spec, action_space, seed)
         self._llm = llm
@@ -62,6 +63,7 @@ class CSPApproach(BaseApproach[_ObsType, _ActType]):
         self._disable_learning = disable_learning
         self._motion_planning_quality = motion_planning_quality
         self._csp_save_dir = Path(csp_save_dir) if csp_save_dir else None
+        self._lifelong_learning = lifelong_learning
         self._csp_generator = self._create_csp_generator()
 
     def reset(
@@ -192,6 +194,7 @@ class CSPApproach(BaseApproach[_ObsType, _ActType]):
             meal_model = MealSpecMealPreferenceModel(
                 self._scene_spec.universal_meal_specs,
                 self._scene_spec.preference_shift_spec,
+                lifelong_learning=self._lifelong_learning,
             )
             return CookingCSPGenerator(
                 self._scene_spec,

--- a/src/multitask_personalization/utils.py
+++ b/src/multitask_personalization/utils.py
@@ -3,7 +3,6 @@
 import os
 from pathlib import Path
 from typing import Any
-import logging
 
 import graphviz
 import numpy as np

--- a/src/multitask_personalization/utils.py
+++ b/src/multitask_personalization/utils.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 from typing import Any
+import logging
 
 import graphviz
 import numpy as np


### PR DESCRIPTION
Some parameter tweaks and various fixes. Below are some issues I have encountered, and things I have tried to resolve them.

- Model eval performance not picking up after preference shift / misaligned between train and eval and across seeds
    - Need to only do preference shift in the train env, and sync the new parameters to eval env
    - Can't shift preference after whole meal completion, otherwise the time step of preference shift will be different across seeds. For now using training iteration(step) to shift preference.
- Model peak eval performance gradually decreasing with number of shifts
    - Seems that this is because the parameter shift would compound and move away from the default max range that the samplers sample solutions from. For now, I increased that default range in cooking_meals.py. Another approach could be to always do the drift starting from the fixed initial parameters instead of compounding it over iterations.
- Fail with CSP solver unable to find a solution
    - I'm still not sure what might be cause this and could use some insights. For now it seems that making the satisfactory range of the parameters larger reduces the occurrence. I tried increasing solver iters but it didn't help much. 
    - Out of the five methods each with 10 seeds in the attached result below, nothing-personal failed 2 runs for this issue, all other methods worked out fine.
  
Some other items:
- Do we want to deterministically shift preference, or randomly choose whether or not to sample? Adding randomness here would make plotting impossible since the timing of the shift would not be synchronized. Easiest way I'm thinking is to randomly sample when to shift preference, and just do the same across seeds, with different scale factors of the drift but the same timing.
- It'd be great if we could have a multi-processing setup, but my initial attempts with the JobLib launcher errored out. https://hydra.cc/docs/plugins/joblib_launcher/.


The result below is with CBTL + periodic reset. All other methods do not have resets at all. 

![Screenshot 2025-04-24 at 2 55 44 AM](https://github.com/user-attachments/assets/1b30ec9b-baa8-4d16-8d86-c77d1171cc1e)
